### PR TITLE
Fix python bindings

### DIFF
--- a/python/UPDATING.md
+++ b/python/UPDATING.md
@@ -14,6 +14,11 @@ from .agency_extensions import tfnsw_vehicle_pb2 as agency__extensions_dot_tfnsw
 from .agency_extensions import mtas_realtime_pb2 as agency__extensions_dot_mtas__realtime__pb2
 ```
 
+And in `mtas_realtime_pb2.py` (add two leading periods)
+```python
+from ..gtfs_spec.gtfs_realtime.proto import gtfs_realtime_pb2 as gtfs__spec_dot_gtfs__realtime_dot_proto_dot_gtfs__realtime__pb2
+```
+
 
 Add the license header back to the generated source file.
 

--- a/python/google/transit/agency_extensions/mtas_realtime_pb2.py
+++ b/python/google/transit/agency_extensions/mtas_realtime_pb2.py
@@ -13,7 +13,7 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
-from gtfs_spec.gtfs_realtime.proto import gtfs_realtime_pb2 as gtfs__spec_dot_gtfs__realtime_dot_proto_dot_gtfs__realtime__pb2
+from ..gtfs_spec.gtfs_realtime.proto import gtfs_realtime_pb2 as gtfs__spec_dot_gtfs__realtime_dot_proto_dot_gtfs__realtime__pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(

--- a/python/google/transit/transit_extensions_pb2.py
+++ b/python/google/transit/transit_extensions_pb2.py
@@ -13,9 +13,9 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
-from gtfs_spec.gtfs_realtime.proto import gtfs_realtime_pb2 as gtfs__spec_dot_gtfs__realtime_dot_proto_dot_gtfs__realtime__pb2
-from agency_extensions import tfnsw_vehicle_pb2 as agency__extensions_dot_tfnsw__vehicle__pb2
-from agency_extensions import mtas_realtime_pb2 as agency__extensions_dot_mtas__realtime__pb2
+from .gtfs_spec.gtfs_realtime.proto import gtfs_realtime_pb2 as gtfs__spec_dot_gtfs__realtime_dot_proto_dot_gtfs__realtime__pb2
+from .agency_extensions import tfnsw_vehicle_pb2 as agency__extensions_dot_tfnsw__vehicle__pb2
+from .agency_extensions import mtas_realtime_pb2 as agency__extensions_dot_mtas__realtime__pb2
 
 
 DESCRIPTOR = _descriptor.FileDescriptor(


### PR DESCRIPTION
this fixes the latest python bindings. as was noted in the UPDATING doc, the extensions are generated with seemingly the wrong import paths, so they need to be modified after they are generated. don't know if it is worth looking into though, as the fix is easy.