### PR TITLE
WIP support split service

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gtfs-realtime-bindings-transit",
-    "version": "1.8.7",
+    "version": "1.8.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "gtfs-realtime-bindings-transit",
-            "version": "1.8.7",
+            "version": "1.8.8",
             "dependencies": {
                 "protobufjs": "=7.2.5"
             },

--- a/nodejs/types.d.ts
+++ b/nodejs/types.d.ts
@@ -1,6 +1,5 @@
 import * as $protobuf from "protobufjs";
 import { Long } from "protobufjs";
-
 /** Properties of a TransitAlertExtension. */
 export interface ITransitAlertExtension {
 

--- a/rust/gtfs-spec-no-extensions/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/rust/gtfs-spec-no-extensions/gtfs-realtime/proto/gtfs-realtime.proto
@@ -1279,8 +1279,7 @@ message ReplacementStop {
   // modifications to the spec.
   extensions 1000 to 1999;
 
-  // The following extension IDs are reserved for private use by any organization.
-  extensions 9000 to 9999;
+  optional TransitReplacementStopExtension transit_replacement_stop_extension = 9514;
 }
 
 message TransitModificationExtension {
@@ -1292,15 +1291,16 @@ message TransitModificationExtension {
 
   // Modification to identify that whole modification
   optional string modification_id = 3;
-
-  // This indicates that through travel is prohibited. Riders will be instructed by consuming apps to disembark from the vehicle.
-  // [If replacement_stops are empty] Through travel is prohibited between the start stop selector and end stop selecter
-  // [If replacement_stops are defined] Travel prohibited between the last replacement stop and the end stop selector.
-  optional bool no_through_travel = 4;
-
-  // Because these trips are effectively operating in two or more segments, we need to indicate the shape_id for the next segment of stops.
-  // This shape is asociated with the followig stops:
-  //   - [If this is the only modification with shape_id_after_end_stop defined]: From the stop after the end_stop_selector until the last stop on the scheduled trip
-  //   - [If there are multiple modifications with shape_id_after_end_stop defined]: From the stop after the end_stop_selector until the next modification with shape_id_after_end_stop defined. The shape be associated with all stops until the start_stop_selector, or the last replacement_stop (if defined) in that next modification.  
-  optional string shape_id_after_end_stop = 5;
 }
+
+message TransitReplacementStopExtension {
+  // Indicates that vehicles will not continue travelling. Riders must disembark
+  // from the vehicle.
+  optional bool no_through_travel = 1;
+
+  // If the vehicle is not operating in revenue service beyond this stop, this field
+  // must be populated with a new shape ID for the next segment of stops.bool
+  // Additionally, when populated, this 
+  optional string next_shape_id = 2;
+}
+

--- a/rust/gtfs-spec-no-extensions/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/rust/gtfs-spec-no-extensions/gtfs-realtime/proto/gtfs-realtime.proto
@@ -1294,13 +1294,8 @@ message TransitModificationExtension {
 }
 
 message TransitReplacementStopExtension {
-  // Indicates that vehicles will not continue travelling. Riders must disembark
-  // from the vehicle.
+  // See `transit-extensions.proto`
   optional bool no_through_travel = 1;
-
-  // If the vehicle is not operating in revenue service beyond this stop, this field
-  // must be populated with a new shape ID for the next segment of stops.bool
-  // Additionally, when populated, this 
   optional string next_shape_id = 2;
 }
 

--- a/rust/gtfs-spec-no-extensions/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/rust/gtfs-spec-no-extensions/gtfs-realtime/proto/gtfs-realtime.proto
@@ -1292,4 +1292,15 @@ message TransitModificationExtension {
 
   // Modification to identify that whole modification
   optional string modification_id = 3;
+
+  // This indicates that through travel is prohibited. Riders will be instructed by consuming apps to disembark from the vehicle.
+  // [If replacement_stops are empty] Through travel is prohibited between the start stop selector and end stop selecter
+  // [If replacement_stops are defined] Travel prohibited between the last replacement stop and the end stop selector.
+  optional bool no_through_travel = 4;
+
+  // Because these trips are effectively operating in two or more segments, we need to indicate the shape_id for the next segment of stops.
+  // This shape is asociated with the followig stops:
+  //   - [If this is the only modification with shape_id_after_end_stop defined]: From the stop after the end_stop_selector until the last stop on the scheduled trip
+  //   - [If there are multiple modifications with shape_id_after_end_stop defined]: From the stop after the end_stop_selector until the next modification with shape_id_after_end_stop defined. The shape be associated with all stops until the start_stop_selector, or the last replacement_stop (if defined) in that next modification.  
+  optional string shape_id_after_end_stop = 5;
 }

--- a/transit-extensions.proto
+++ b/transit-extensions.proto
@@ -149,6 +149,10 @@ message TransitReplacementStopExtension {
   optional string next_shape_id = 2;
 }
 
+message TransitModifiedTripSelector {
+  optional int32 split_service_segment_index = 1;
+}
+
 extend transit_realtime.TripModifications.Modification {
   optional TransitModificationExtension transit_modification_extension = 9514;
 }
@@ -156,3 +160,8 @@ extend transit_realtime.TripModifications.Modification {
 extend transit_realtime.ReplacementStop {
   optional TransitReplacementStopExtension transit_replacement_stop_extension = 9514;
 }
+
+extend transit_realtime.TripDescriptor.ModifiedTripSelector {
+  optional TransitModifiedTripSelector transit_modified_trip_selector_extension = 9514;
+}
+

--- a/transit-extensions.proto
+++ b/transit-extensions.proto
@@ -145,8 +145,7 @@ message TransitReplacementStopExtension {
   optional bool no_through_travel = 1;
 
   // If the vehicle is not operating in revenue service beyond this stop, this field
-  // must be populated with a new shape ID for the next segment of stops.bool
-  // Additionally, when populated, this 
+  // must be populated with a new shape ID for the next segment of stops.
   optional string next_shape_id = 2;
 }
 

--- a/transit-extensions.proto
+++ b/transit-extensions.proto
@@ -137,21 +137,23 @@ message TransitModificationExtension {
 
   // Modification to identify that whole modification
   optional string modification_id = 3;
+}
 
+message TransitReplacementStopExtension {
+  // Indicates that vehicles will not continue travelling. Riders must disembark
+  // from the vehicle.
+  optional bool no_through_travel = 1;
 
-  // This indicates that through travel is prohibited. Riders will be instructed by consuming apps to disembark from the vehicle.
-  // [If replacement_stops are empty] Through travel is prohibited between the start stop selector and end stop selecter
-  // [If replacement_stops are defined] Travel prohibited between the last replacement stop and the end stop selector.
-  optional bool no_through_travel = 4;
-
-  // Because these trips are effectively operating in two or more segments, we need to indicate the shape_id for the next segment of stops.
-  // The segments with no_through_travel applied according to the logic above do not have an associated shape, because the vehicle is not in revenue service for those bits. 
-  // The shape defined in the SelectedTrips is applied to the first stop on the itinerary until the start_stop_selector or the last replacement stop in the first modification with shape_id_after_end_stop defined.
-  // - [If this is the only modification with shape_id_after_end_stop defined]: From the stop after the end_stop_selector until the last stop on the scheduled trip
-  // - [If there are multiple modifications with shape_id_after_end_stop defined]: From the stop after the end_stop_selector until the next modification with shape_id_after_end_stop defined. The shape be associated with all stops until the start_stop_selector, or the last replacement_stop (if defined) in that next modification.  
-  optional string shape_id_after_end_stop = 5;
+  // If the vehicle is not operating in revenue service beyond this stop, this field
+  // must be populated with a new shape ID for the next segment of stops.bool
+  // Additionally, when populated, this 
+  optional string next_shape_id = 2;
 }
 
 extend transit_realtime.TripModifications.Modification {
   optional TransitModificationExtension transit_modification_extension = 9514;
+}
+
+extend transit_realtime.ReplacementStop {
+  optional TransitReplacementStopExtension transit_replacement_stop_extension = 9514;
 }

--- a/transit-extensions.proto
+++ b/transit-extensions.proto
@@ -142,11 +142,11 @@ message TransitModificationExtension {
 message TransitReplacementStopExtension {
   // Indicates that vehicles will not continue travelling. Riders must disembark
   // from the vehicle.
-  optional bool no_through_travel = 1;
+  required bool no_through_travel = 1;
 
   // If the vehicle is not operating in revenue service beyond this stop, this field
   // must be populated with a new shape ID for the next segment of stops.
-  optional string next_shape_id = 2;
+  required string next_shape_id = 2;
 }
 
 message TransitModifiedTripSelector {

--- a/transit-extensions.proto
+++ b/transit-extensions.proto
@@ -138,21 +138,20 @@ message TransitModificationExtension {
   // Modification to identify that whole modification
   optional string modification_id = 3;
 
-  // Is that modification splitting the service in two, instead of just having a detour
-  // If true, a `secondary_shape_id` should be provided in TransitSelectedTripsExtension
-  optional bool is_splitting_service = 4;
+
+  // This indicates that through travel is prohibited. Riders will be instructed by consuming apps to disembark from the vehicle.
+  // [If replacement_stops are empty] Through travel is prohibited between the start stop selector and end stop selecter
+  // [If replacement_stops are defined] Travel prohibited between the last replacement stop and the end stop selector.
+  optional bool no_through_travel = 4;
+
+  // Because these trips are effectively operating in two or more segments, we need to indicate the shape_id for the next segment of stops.
+  // The segments with no_through_travel applied according to the logic above do not have an associated shape, because the vehicle is not in revenue service for those bits. 
+  // The shape defined in the SelectedTrips is applied to the first stop on the itinerary until the start_stop_selector or the last replacement stop in the first modification with shape_id_after_end_stop defined.
+  // - [If this is the only modification with shape_id_after_end_stop defined]: From the stop after the end_stop_selector until the last stop on the scheduled trip
+  // - [If there are multiple modifications with shape_id_after_end_stop defined]: From the stop after the end_stop_selector until the next modification with shape_id_after_end_stop defined. The shape be associated with all stops until the start_stop_selector, or the last replacement_stop (if defined) in that next modification.  
+  optional string shape_id_after_end_stop = 5;
 }
 
 extend transit_realtime.TripModifications.Modification {
   optional TransitModificationExtension transit_modification_extension = 9514;
-}
-
-message TransitSelectedTripsExtension {
-  // Same as shape_id, but should be provided if the shape is different from the original trip
-  // In that case, shape_id is the first part of the trip, and secondary_shape_id is the second part
-  optional string secondary_shape_id = 1;
-}
-
-extend transit_realtime.TripModifications.SelectedTrips {
-  optional TransitSelectedTripsExtension transit_selected_trips_extension = 9514;
 }

--- a/transit-extensions.proto
+++ b/transit-extensions.proto
@@ -137,8 +137,22 @@ message TransitModificationExtension {
 
   // Modification to identify that whole modification
   optional string modification_id = 3;
+
+  // Is that modification splitting the service in two, instead of just having a detour
+  // If true, a `secondary_shape_id` should be provided in TransitSelectedTripsExtension
+  optional bool is_splitting_service = 4;
 }
 
 extend transit_realtime.TripModifications.Modification {
   optional TransitModificationExtension transit_modification_extension = 9514;
+}
+
+message TransitSelectedTripsExtension {
+  // Same as shape_id, but should be provided if the shape is different from the original trip
+  // In that case, shape_id is the first part of the trip, and secondary_shape_id is the second part
+  optional string secondary_shape_id = 1;
+}
+
+extend transit_realtime.TripModifications.SelectedTrips {
+  optional TransitSelectedTripsExtension transit_selected_trips_extension = 9514;
 }


### PR DESCRIPTION
Support split service by adding 
- a boolean to define if the service is split
- a secondary shape to define the second part of the shape

I think this might be ok for our usecase, but that does mean that there can be only a single split service modification. I don't think that will be ok for the general spec. 