### PR TITLE
Proposing something to permit multiple segments and shapes

### DIFF
--- a/nodejs/package-lock.json
+++ b/nodejs/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "gtfs-realtime-bindings-transit",
-    "version": "1.8.7",
+    "version": "1.8.8",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "gtfs-realtime-bindings-transit",
-            "version": "1.8.7",
+            "version": "1.8.8",
             "dependencies": {
                 "protobufjs": "=7.2.5"
             },

--- a/nodejs/types.d.ts
+++ b/nodejs/types.d.ts
@@ -1,6 +1,5 @@
 import * as $protobuf from "protobufjs";
 import { Long } from "protobufjs";
-
 /** Properties of a TransitAlertExtension. */
 export interface ITransitAlertExtension {
 

--- a/rust/gtfs-spec-no-extensions/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/rust/gtfs-spec-no-extensions/gtfs-realtime/proto/gtfs-realtime.proto
@@ -1279,8 +1279,7 @@ message ReplacementStop {
   // modifications to the spec.
   extensions 1000 to 1999;
 
-  // The following extension IDs are reserved for private use by any organization.
-  extensions 9000 to 9999;
+  optional TransitReplacementStopExtension transit_replacement_stop_extension = 9514;
 }
 
 message TransitModificationExtension {
@@ -1292,15 +1291,16 @@ message TransitModificationExtension {
 
   // Modification to identify that whole modification
   optional string modification_id = 3;
-
-  // This indicates that through travel is prohibited. Riders will be instructed by consuming apps to disembark from the vehicle.
-  // [If replacement_stops are empty] Through travel is prohibited between the start stop selector and end stop selecter
-  // [If replacement_stops are defined] Travel prohibited between the last replacement stop and the end stop selector.
-  optional bool no_through_travel = 4;
-
-  // Because these trips are effectively operating in two or more segments, we need to indicate the shape_id for the next segment of stops.
-  // This shape is asociated with the followig stops:
-  //   - [If this is the only modification with shape_id_after_end_stop defined]: From the stop after the end_stop_selector until the last stop on the scheduled trip
-  //   - [If there are multiple modifications with shape_id_after_end_stop defined]: From the stop after the end_stop_selector until the next modification with shape_id_after_end_stop defined. The shape be associated with all stops until the start_stop_selector, or the last replacement_stop (if defined) in that next modification.  
-  optional string shape_id_after_end_stop = 5;
 }
+
+message TransitReplacementStopExtension {
+  // Indicates that vehicles will not continue travelling. Riders must disembark
+  // from the vehicle.
+  optional bool no_through_travel = 1;
+
+  // If the vehicle is not operating in revenue service beyond this stop, this field
+  // must be populated with a new shape ID for the next segment of stops.bool
+  // Additionally, when populated, this 
+  optional string next_shape_id = 2;
+}
+

--- a/rust/gtfs-spec-no-extensions/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/rust/gtfs-spec-no-extensions/gtfs-realtime/proto/gtfs-realtime.proto
@@ -1294,13 +1294,8 @@ message TransitModificationExtension {
 }
 
 message TransitReplacementStopExtension {
-  // Indicates that vehicles will not continue travelling. Riders must disembark
-  // from the vehicle.
+  // See `transit-extensions.proto`
   optional bool no_through_travel = 1;
-
-  // If the vehicle is not operating in revenue service beyond this stop, this field
-  // must be populated with a new shape ID for the next segment of stops.bool
-  // Additionally, when populated, this 
   optional string next_shape_id = 2;
 }
 

--- a/rust/gtfs-spec-no-extensions/gtfs-realtime/proto/gtfs-realtime.proto
+++ b/rust/gtfs-spec-no-extensions/gtfs-realtime/proto/gtfs-realtime.proto
@@ -1292,4 +1292,15 @@ message TransitModificationExtension {
 
   // Modification to identify that whole modification
   optional string modification_id = 3;
+
+  // This indicates that through travel is prohibited. Riders will be instructed by consuming apps to disembark from the vehicle.
+  // [If replacement_stops are empty] Through travel is prohibited between the start stop selector and end stop selecter
+  // [If replacement_stops are defined] Travel prohibited between the last replacement stop and the end stop selector.
+  optional bool no_through_travel = 4;
+
+  // Because these trips are effectively operating in two or more segments, we need to indicate the shape_id for the next segment of stops.
+  // This shape is asociated with the followig stops:
+  //   - [If this is the only modification with shape_id_after_end_stop defined]: From the stop after the end_stop_selector until the last stop on the scheduled trip
+  //   - [If there are multiple modifications with shape_id_after_end_stop defined]: From the stop after the end_stop_selector until the next modification with shape_id_after_end_stop defined. The shape be associated with all stops until the start_stop_selector, or the last replacement_stop (if defined) in that next modification.  
+  optional string shape_id_after_end_stop = 5;
 }

--- a/transit-extensions.proto
+++ b/transit-extensions.proto
@@ -149,6 +149,10 @@ message TransitReplacementStopExtension {
   optional string next_shape_id = 2;
 }
 
+message TransitModifiedTripSelector {
+  optional int32 split_service_segment_index = 1;
+}
+
 extend transit_realtime.TripModifications.Modification {
   optional TransitModificationExtension transit_modification_extension = 9514;
 }
@@ -156,3 +160,8 @@ extend transit_realtime.TripModifications.Modification {
 extend transit_realtime.ReplacementStop {
   optional TransitReplacementStopExtension transit_replacement_stop_extension = 9514;
 }
+
+extend transit_realtime.TripDescriptor.ModifiedTripSelector {
+  optional TransitModifiedTripSelector transit_modified_trip_selector_extension = 9514;
+}
+

--- a/transit-extensions.proto
+++ b/transit-extensions.proto
@@ -145,8 +145,7 @@ message TransitReplacementStopExtension {
   optional bool no_through_travel = 1;
 
   // If the vehicle is not operating in revenue service beyond this stop, this field
-  // must be populated with a new shape ID for the next segment of stops.bool
-  // Additionally, when populated, this 
+  // must be populated with a new shape ID for the next segment of stops.
   optional string next_shape_id = 2;
 }
 

--- a/transit-extensions.proto
+++ b/transit-extensions.proto
@@ -137,21 +137,23 @@ message TransitModificationExtension {
 
   // Modification to identify that whole modification
   optional string modification_id = 3;
+}
 
+message TransitReplacementStopExtension {
+  // Indicates that vehicles will not continue travelling. Riders must disembark
+  // from the vehicle.
+  optional bool no_through_travel = 1;
 
-  // This indicates that through travel is prohibited. Riders will be instructed by consuming apps to disembark from the vehicle.
-  // [If replacement_stops are empty] Through travel is prohibited between the start stop selector and end stop selecter
-  // [If replacement_stops are defined] Travel prohibited between the last replacement stop and the end stop selector.
-  optional bool no_through_travel = 4;
-
-  // Because these trips are effectively operating in two or more segments, we need to indicate the shape_id for the next segment of stops.
-  // The segments with no_through_travel applied according to the logic above do not have an associated shape, because the vehicle is not in revenue service for those bits. 
-  // The shape defined in the SelectedTrips is applied to the first stop on the itinerary until the start_stop_selector or the last replacement stop in the first modification with shape_id_after_end_stop defined.
-  // - [If this is the only modification with shape_id_after_end_stop defined]: From the stop after the end_stop_selector until the last stop on the scheduled trip
-  // - [If there are multiple modifications with shape_id_after_end_stop defined]: From the stop after the end_stop_selector until the next modification with shape_id_after_end_stop defined. The shape be associated with all stops until the start_stop_selector, or the last replacement_stop (if defined) in that next modification.  
-  optional string shape_id_after_end_stop = 5;
+  // If the vehicle is not operating in revenue service beyond this stop, this field
+  // must be populated with a new shape ID for the next segment of stops.bool
+  // Additionally, when populated, this 
+  optional string next_shape_id = 2;
 }
 
 extend transit_realtime.TripModifications.Modification {
   optional TransitModificationExtension transit_modification_extension = 9514;
+}
+
+extend transit_realtime.ReplacementStop {
+  optional TransitReplacementStopExtension transit_replacement_stop_extension = 9514;
 }

--- a/transit-extensions.proto
+++ b/transit-extensions.proto
@@ -142,11 +142,11 @@ message TransitModificationExtension {
 message TransitReplacementStopExtension {
   // Indicates that vehicles will not continue travelling. Riders must disembark
   // from the vehicle.
-  optional bool no_through_travel = 1;
+  required bool no_through_travel = 1;
 
   // If the vehicle is not operating in revenue service beyond this stop, this field
   // must be populated with a new shape ID for the next segment of stops.
-  optional string next_shape_id = 2;
+  required string next_shape_id = 2;
 }
 
 message TransitModifiedTripSelector {

--- a/transit-extensions.proto
+++ b/transit-extensions.proto
@@ -138,21 +138,20 @@ message TransitModificationExtension {
   // Modification to identify that whole modification
   optional string modification_id = 3;
 
-  // Is that modification splitting the service in two, instead of just having a detour
-  // If true, a `secondary_shape_id` should be provided in TransitSelectedTripsExtension
-  optional bool is_splitting_service = 4;
+
+  // This indicates that through travel is prohibited. Riders will be instructed by consuming apps to disembark from the vehicle.
+  // [If replacement_stops are empty] Through travel is prohibited between the start stop selector and end stop selecter
+  // [If replacement_stops are defined] Travel prohibited between the last replacement stop and the end stop selector.
+  optional bool no_through_travel = 4;
+
+  // Because these trips are effectively operating in two or more segments, we need to indicate the shape_id for the next segment of stops.
+  // The segments with no_through_travel applied according to the logic above do not have an associated shape, because the vehicle is not in revenue service for those bits. 
+  // The shape defined in the SelectedTrips is applied to the first stop on the itinerary until the start_stop_selector or the last replacement stop in the first modification with shape_id_after_end_stop defined.
+  // - [If this is the only modification with shape_id_after_end_stop defined]: From the stop after the end_stop_selector until the last stop on the scheduled trip
+  // - [If there are multiple modifications with shape_id_after_end_stop defined]: From the stop after the end_stop_selector until the next modification with shape_id_after_end_stop defined. The shape be associated with all stops until the start_stop_selector, or the last replacement_stop (if defined) in that next modification.  
+  optional string shape_id_after_end_stop = 5;
 }
 
 extend transit_realtime.TripModifications.Modification {
   optional TransitModificationExtension transit_modification_extension = 9514;
-}
-
-message TransitSelectedTripsExtension {
-  // Same as shape_id, but should be provided if the shape is different from the original trip
-  // In that case, shape_id is the first part of the trip, and secondary_shape_id is the second part
-  optional string secondary_shape_id = 1;
-}
-
-extend transit_realtime.TripModifications.SelectedTrips {
-  optional TransitSelectedTripsExtension transit_selected_trips_extension = 9514;
 }


### PR DESCRIPTION
# Supporting split service in GTFS-RT Trip Modifications

GTFS-RT Trip Modifications allow data-producers to communicate detours to active trips in real-time or near-real time. It is not, however, currently possible to tell data-consumers about service disruptions that result in service being operated in two or more discrete segments. This proposal includes a new, scoped extension to the ReplacementStop object, which will producers to define when through-service is not possible, and to associate disparate trip-segments with their respective shapes.

At a high level, when riders must disembark from a vehicle at a stop, that stop is considered "modified." As such, it should be removed from the selectedTrips, and may be added back as a replacement stop.

## Proposed change

To communicate split servive, data producers should add a replacement stop that contains the boolean "no_through_travel" at the last served stop. This may be a stop on the original itinerary, an existing stop that isn't typically served by this itinerary, or a temporary stop.

`no_through_travel` is conditionally required when `next_shape_id` is defined, but `no_through_travel` may be `true` without requiring a new shape (see example 4).

```protobuf
message TransitReplacementStopExtension {
  // Indicates that vehicles will not continue travelling. Riders must disembark
  // from the vehicle.
  optional bool no_through_travel = 1;

  // If the vehicle is not operating in revenue service beyond this stop, this field
  // must be populated with a new shape ID for the next segment of stops.bool
  // Additionally, when populated, this
  optional string next_shape_id = 2;
}

extend transit_realtime.ReplacementStop {
  optional TransitReplacementStopExtension transit_replacement_stop_extension = 9514;
}

```

## Example 1: Parade Disruption

A downtown parade prevents trips 100, 200, and 300 from following their usual route, splitting service into two segments:

- Riders must disembark at stop ID 4.
- Stops 4 through 7 are not served.
- Riders may board at stop 8.

```json
{
  "header": {
    "gtfsRealtimeVersion": "2.0",
    "timestamp": "1738697269"
  },
  "entity": [
    {
      "id": "shape_stops_1-4",
      "shape": { "shapeId": "shape_stops_1-4", "encodedPolyline": "[...]" }
    },
    {
      "id": "shape_stops_8-11",
      "shape": { "shapeId": "shape_stops_8-11", "encodedPolyline": "[...]" }
    },
    {
      "id": "modification_1",
      "tripModifications": {
        "selectedTrips": [
          { "tripIds": ["100", "200", "300"], "shapeId": "shape_stops_1-4" }
        ],
        "modifications": [
          {
            "startStopSelector": { "stopId": "4" },
            "endStopSelector": { "stopId": "7" },
            "replacementStops": [
              {
                "stop_id": "4",
                ".transit_replacement_stop_extension": {
                  "no_through_travel": true,
                  "next_shape_id": "shape_stops_8-11"
                }
              }
            ]
          }
        ]
      }
    }
  ]
}
```

![tm-split-service-example_Example 1](https://github.com/user-attachments/assets/597af59c-4ffb-4650-b45e-06e14fbf0083)

## Example 2: Bridge Closure

A temporary bridge closure forces trips 400, 500, and 600 to operate in two segments. To faciliate rider travel, it is detouring to the ferry slips on either bank.

- The first segment ends at a temporary stop (`ferry_slip_e`).
- Riders must disembark at `ferry_slip_e`.
- The shape for stops 1 to `ferry_slip_e` is defined in `selectedTrips`, while the shape from `ferry_slip_w` to stop 11 is defined in the temporary stop `ferry_slip_e`.

```json
{
  "header": { "gtfsRealtimeVersion": "2.0", "timestamp": "1738697269" },
  "entity": [
    {
      "id": "shape_stops_1-ferry_slip_east",
      "shape": {
        "shapeId": "shape_stops_1-ferry_slip_east",
        "encodedPolyline": "[...]"
      }
    },
    {
      "id": "shape_stops_ferry_slip_west-11",
      "shape": {
        "shapeId": "shape_stops_ferry_slip_west-11",
        "encodedPolyline": "[...]"
      }
    },
    {
      "id": "modification_1",
      "tripModifications": {
        "selectedTrips": [
          {
            "tripIds": ["400", "500", "600"],
            "shapeId": "shape_stops_1-ferry_slip_east"
          }
        ],
        "modifications": [
          {
            "startStopSelector": { "stopId": "5" },
            "endStopSelector": { "stopId": "7" },
            "replacementStops": [
              {
                "stop_id": "ferry_slip_east",
                ".transit_modification_extension": {
                  "no_through_travel": true,
                  "next_shape_id": "shape_stops_ferry_slip_west-11"
                }
              },
              {
                "stop_id": "ferry_slip_west"
              }
            ]
          }
        ]
      }
    }
  ]
}
```

![tm-split-service-example_Example 2](https://github.com/user-attachments/assets/664f8567-6afd-4ec8-8f1d-a8f414f12d48)

## Example 3: Flooded Streets

A water main break has complicated downtown travel. Several streets are impassible and service is divided into three distinct segments with separate shapes.

- Riders must disembark at stops 3 and 7.

```json
{
  "header": { "gtfsRealtimeVersion": "2.0", "timestamp": "1738697269" },
  "entity": [
    {
      "id": "shape_stops_1-3",
      "shape": { "shapeId": "shape_stops_1-3", "encodedPolyline": "[...]" }
    },
    {
      "id": "shape_stops_4-7",
      "shape": { "shapeId": "shape_stops_4-7", "encodedPolyline": "[...]" }
    },
    {
      "id": "shape_stops_9-11",
      "shape": { "shapeId": "shape_stops_9-11", "encodedPolyline": "[...]" }
    },
    {
      "id": "modification_1",
      "tripModifications": {
        "selectedTrips": [
          { "tripIds": ["700", "800", "900"], "shapeId": "shape_stops_1-3" }
        ],
        "modifications": [
          {
            "startStopSelector": { "stopId": "3" },
            "endStopSelector": { "stopId": "3" },
            "replacementStops": [
              {
                "stop_id": "3",
                ".transit_modification_extension": {
                  "no_through_travel": true,
                  "next_shape_id": "shape_stops_4-7"
                }
              }
            ]
          },
          {
            "startStopSelector": { "stopId": "7" },
            "endStopSelector": { "stopId": "8" },
            "replacementStops": [
              {
                "stop_id": "7",
                ".transit_modification_extension": {
                  "no_through_travel": true,
                  "next_shape_id": "shape_stops_9-11"
                }
              }
            ]
          }
        ]
      }
    }
  ]
}
```

![tm-split-service-example_Example 3](https://github.com/user-attachments/assets/4f20263f-3196-4c83-b737-c14c007717cf)

## Example 4: Shuttle bus bridge

There are emergency roadworks at an intersection. The maximum turning radius is significantly decreased, and the operator must use midi buses for the second half of a route. All stops are served, but riders must exit the articulated bus and board another vehicle.

Because stop 5 is effectively served twice (once dropping off by the articulated bus, and once by the midi-bus), we must include it twice in the replacement stops.

```json
{
  "header": { "gtfsRealtimeVersion": "2.0", "timestamp": "1738697269" },
  "entity": [
    {
      "id": "shape1",
      "shape": {
        "shapeId": "shape1",
        "encodedPolyline": "[...]"
      }
    },
    {
      "id": "modification_1",
      "tripModifications": {
        "selectedTrips": [
          {
            "tripIds": ["1000", "1100", "1200"],
            "shapeId": "shape1"
          }
        ],
        "modifications": [
          {
            "startStopSelector": { "stopId": "5" },
            "endStopSelector": { "stopId": "5" },
            "replacementStops": [
              {
                "stop_id": "5",
                ".transit_modification_extension": {
                  "no_through_travel": true
                }
              },
              {
                "stop_id": "5"
              }
            ]
          }
        ]
      }
    }
  ]
}
```
![tm-split-service-example_Example 4](https://github.com/user-attachments/assets/488bad93-41f0-4714-93e6-ebf5762eaf99)

# Communicating trip updates on split service segments

When service is split, we need to ensure that trip updates can unambiguously refer to a specific segment of the divided trip. To this end, we propose an extension to the [ModifiedTripSelector](https://gtfs.org/documentation/realtime/reference/#message-modifiedtripselector). Data producers must use the original trip ID in combination with the index of the split service. The value is one-base-indexed (starting at 1), and (unlike `sequence` values elsewhere in GTFS) must increment by one at a time. In example one,  `split_service_segment_index: 1` refers to the service between 1 and 4, while `split_service_segment_index: 2` refers to stops 8 through 9. Put differently, every time `no_through_travel` is true, the index increments by one.

As with all trip updates on modified trips, the trip_id must be included in the ModifiedTripSelector, but not the TripSelector. Additionally, providing a TripUpdate with a ModifiedTripSelector is the only way to create predictions on trips with split service.

```protobuf
message TransitModifiedTripSelector {
  optional int32 split_service_segment_index = 1;
}
```
