### PR TITLE
Add ESM compatible export

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -15,7 +15,8 @@
     },
     "exports": {
         "types": "./types.d.ts",
-        "require": "./gtfs-realtime.js"
+        "require": "./gtfs-realtime.js",
+        "import": "./gtfs-realtime.js"
     },
     "main": "./gtfs-realtime.js",
     "types": "./types.d.ts",


### PR DESCRIPTION
This allows users to access the library using ESM style imports
```
import * as GtfsRealtimeBindings from 'gtfs-realtime-bindings-transit'
```